### PR TITLE
Ignoring temporary VIM files, added modelines to all files except .json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules
 public/css/*.css.map
 public/css/*.css
 public/logs/*
+
+# Temporary VIM files
+*.*~
+*.swp

--- a/backend.js
+++ b/backend.js
@@ -533,3 +533,5 @@ io.sockets.on('connection', function (socket) {
 // listen for connections
 console.log('starting http/socket-server on port %s', config.port);
 server.listen(config.port, '::')
+/* vim: ts=4:sw=4:noet 
+ */

--- a/cli.js
+++ b/cli.js
@@ -9,3 +9,5 @@ cli.on('connect', function() {
 cli.on('line', function(stamp, line, duration) {
 	console.log(line);
 });
+/* vim: ts=4:sw=4:noet 
+ */

--- a/public/beamer.html
+++ b/public/beamer.html
@@ -19,4 +19,5 @@
 			<h1></h1>
 		</main>
 	</body>
+    <!-- vim: set sw=4 ts=4 noet: -->
 </html>

--- a/public/js/beamer.js
+++ b/public/js/beamer.js
@@ -53,3 +53,5 @@ $(function() {
 		});
 	}
 });
+/* vim: ts=4:sw=4:noet
+ */

--- a/public/js/read.js
+++ b/public/js/read.js
@@ -68,3 +68,5 @@ $(function() {
 		$lines.autoScale();
 	});
 });
+/* vim: ts=4:sw=4:noet
+ */

--- a/public/js/write.js
+++ b/public/js/write.js
@@ -397,3 +397,5 @@ $(function() {
 		}
 	}
 });
+/* vim: ts=4:sw=4:noet
+ */

--- a/public/read.html
+++ b/public/read.html
@@ -54,4 +54,5 @@
 			Help! Connection lost.
 		</section>
 	</body>
+    <!-- vim: set sw=4 ts=4 noet: -->
 </html>

--- a/public/write.html
+++ b/public/write.html
@@ -169,4 +169,5 @@
 			<input />
 		</main>
 	</body>
+    <!-- vim: set sw=4 ts=4 noet: -->
 </html>


### PR DESCRIPTION
As discussed in #18 I moved the VIM specific parts into a separate PR.

To respect the tab as indent I added modelines (and tested them. They work as expected).
